### PR TITLE
Build JEPMap using JIRA Rest API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>default-cli</id>

--- a/src/main/java/com/chrisnewland/jepmap/JEP.java
+++ b/src/main/java/com/chrisnewland/jepmap/JEP.java
@@ -218,8 +218,13 @@ public class JEP
 		if (atPos != -1)
 		{
 			listName = listName.substring(0, atPos).replace("dash", "-").replace(" ", "");
+			return listName;
 		}
 
+		atPos = listName.indexOf("@");
+		if (atPos != -1) {
+			listName = listName.substring(0, atPos);
+		}
 		return listName;
 	}
 


### PR DESCRIPTION
OpenJDK issue tracker is a JIRA instance and offers a rest API to  search issues. We can filter on issueType = JEP and query the all  JEPs to build the JEPMap instead of parsing OpenJDK html pages.

# TODO
- Project IDs are currently not handled. It is possible to get the project ID from discussion field. But the other way of parsing the JEP description may not be useful with the API because I cheked a couple of JEPs and links were missing. I'll need to look further to find an example JEP which is mapped that way and see if its possible to retrieve the info from rest API.